### PR TITLE
Convert to alpine builder + runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,32 @@
-FROM golang:1.10
+FROM golang:1.11-alpine3.8 as builder
 
-# For later timing purposes
-RUN apt-get update && apt-get install -y wget
+# We assume only git is needed for all dependencies.
+# openssl is already built-in.
+RUN apk add -U --no-cache git
 
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    # Clean packages
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && apt-get clean
-
-# We use Disconnnect24 as the name is hardcoded into patch's source code.
-WORKDIR /go/src/github.com/Disconnect24/Mail-Go
-COPY get.sh /go/src/github.com/Disconnect24/Mail-Go
+WORKDIR /go/src/github.com/RiiConnect24/Mail-Go
+COPY get.sh /go/src/github.com/RiiConnect24/Mail-Go
 RUN sh get.sh
 
-# Copy needed parts of the Mail-Go source into builder's source,
+# Copy necessary parts of the Mail-Go source into builder's source
 COPY *.go ./
 COPY patch patch
 
-RUN go get ./...
-
 # Build to name "app".
-RUN GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o app .
+RUN go build -o app .
+
+###########
+# RUNTIME #
+###########
+FROM alpine:3.8
+
+WORKDIR /go/src/github.com/RiiConnect24/Mail-Go/
+COPY --from=builder /go/src/github.com/RiiConnect24/Mail-Go/ .
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && apk add -U --no-cache ca-certificates
 
 # Wait until there's an actual MySQL connection we can use to start.
-CMD ["dockerize", "-wait", "tcp://127.0.0.1:3306", "-timeout", "60s", "/go/src/github.com/Disconnect24/Mail-Go/app"]
+CMD ["dockerize", "-wait", "tcp://database:3306", "-timeout", "60s", "/go/src/github.com/RiiConnect24/Mail-Go/app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mail:
     build: .
     volumes:
-      - ./config:/go/src/github.com/Disconnect24/Mail-Go/config
+      - ./config:/go/src/github.com/RiiConnect24/Mail-Go/config
     ports:
       # Container 80 -> Host 8080
       - "8080:80"

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/Disconnect24/Mail-Go/patch"
+	"github.com/RiiConnect24/Mail-Go/patch"
 	"github.com/getsentry/raven-go"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/logrusorgru/aurora"

--- a/send.go
+++ b/send.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"database/sql"
 	"fmt"
-	"github.com/Disconnect24/Mail-Go/patch"
+	"github.com/RiiConnect24/Mail-Go/patch"
 	"github.com/google/uuid"
 	"net/http"
 	"net/smtp"

--- a/wiimail.go
+++ b/wiimail.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/Disconnect24/Mail-GO/utilities"
 	"github.com/nfnt/resize"
 
 	"image"
@@ -29,7 +28,7 @@ import (
 const CRLF = "\r\n"
 
 func FormulateMail(from string, to string, subject string, body string, potentialImage []byte) (string, error) {
-	boundary := utilities.GenerateBoundary()
+	boundary := GenerateBoundary()
 
 	// Set up headers and set up first boundary with body.
 	// The body could be empty: that's fine, it'll have no value


### PR DESCRIPTION
This reduces base image size from `824MB` to `372MB` for build/cache and `25.3MB` for the runner.