### PR TITLE
Verify consistency between mlid and MAIL FROM (fixes #29)

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -17,7 +17,7 @@ func Delete(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		return
 	}
 
-	isVerified, err := Auth(r.Form)
+	isVerified, wiiID, err := Auth(r.Form)
 	if err != nil {
 		fmt.Fprintf(w, GenNormalErrorCode(541, "Something weird happened."))
 		LogError("Error parsing delete authentication", err)
@@ -26,9 +26,6 @@ func Delete(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		fmt.Fprintf(w, GenNormalErrorCode(240, "An authentication error occurred."))
 		return
 	}
-
-	// We don't need to check mlid as it's been verified by Auth above.
-	wiiID := r.Form.Get("mlid")
 
 	delnum := r.Form.Get("delnum")
 	actualDelnum, err := strconv.Atoi(delnum)

--- a/receive.go
+++ b/receive.go
@@ -21,7 +21,7 @@ func Receive(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		return
 	}
 
-	isVerified, err := Auth(r.Form)
+	isVerified, mlidWithW, err := Auth(r.Form)
 	if err != nil {
 		fmt.Fprintf(w, GenNormalErrorCode(531, "Something weird happened."))
 		LogError("Error receiving.", err)
@@ -31,9 +31,8 @@ func Receive(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		return
 	}
 
-	// We already know the mlid is valid from previous
+	// We already know the mlid is valid as Auth checks it for us,
 	// so we don't need to further check.
-	mlidWithW := r.Form.Get("mlid")
 
 	if mlidWithW == "" {
 		fmt.Fprintf(w, GenNormalErrorCode(330, "Unable to parse parameters."))


### PR DESCRIPTION
Modifies auth.go such that Auth returns the mlid it verified;
modifies send.go to compare the ID in MAIL FROM with this ID,
and modifies delete.go/receive.go to also pull the mlid returned
by Auth rather than parsing it from form data themselves.

Fixes #29 

Signed-off-by: Lauren Kelly <lauren.kelly@msn.com>