### PR TITLE
Add other connection parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"time"
 )
 
 var global patch.Config
@@ -156,6 +157,8 @@ func main() {
 
 	// Ensure Mail-Go does not overload the backing database.
 	db.SetMaxOpenConns(50)
+	db.SetMaxIdleConns(50)
+	db.SetConnMaxLifetime(time.Second * 10)
 
 	err = db.Ping()
 	if err != nil {


### PR DESCRIPTION
Through tracing, we found that the long-lived prepared statements retained high memory usage.

By specifying further limits, it should drastically reduce memory usage over a shorter time period.